### PR TITLE
Rename “SWH” column to “Archive”

### DIFF
--- a/src/cljs/codegouvfr/core.cljs
+++ b/src/cljs/codegouvfr/core.cljs
@@ -220,7 +220,7 @@
               [:a {:class    (str "button" (when (= rep-f :name) " is-light"))
                    :title    "Trier par ordre alphabétique des noms de dépôts"
                    :on-click #(re-frame/dispatch [:sort-repos-by! :name])} "Organisation / dépôt"]]]
-        [:th [:abbr {:title "SWH"}
+        [:th [:abbr {:title "Archive"}
               [:a {:class "button is-static"
                    :title "Lien vers l'archive de Software Heritage"} "SWH"]]]
         [:th [:abbr {:title "Description"}


### PR DESCRIPTION
Software Heritage is not very well known, and this “SWH” acronym even less so